### PR TITLE
If filetype is unknown, also put '#' in delim map

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -469,11 +469,22 @@ function s:SetUpForNewFiletype(filetype, forceReset)
 endfunction
 
 function s:CreateDelimMapFromCms()
-    return {
-        \ 'left': substitute(&commentstring, '\([^ \t]*\)\s*%s.*', '\1', ''),
-        \ 'right': substitute(&commentstring, '.*%s\s*\(.*\)', '\1', 'g'),
-        \ 'leftAlt': '',
-        \ 'rightAlt': '' }
+    " If the filetype is known, get the comment characters from the commentstring.
+    " If the filetype is unknown, return '#' as main and parse vim's default
+    "   commentstring /*...*/ as the alt.
+    if &filetype !=? ''
+        return {
+            \ 'left': substitute(&commentstring, '\([^ \t]*\)\s*%s.*', '\1', ''),
+            \ 'right': substitute(&commentstring, '.*%s\s*\(.*\)', '\1', 'g'),
+            \ 'leftAlt': '',
+            \ 'rightAlt': '' }
+    else
+        return {
+            \ 'left': '#',
+            \ 'right': '',
+            \ 'leftAlt': substitute(&commentstring, '\([^ \t]*\)\s*%s.*', '\1', ''),
+            \ 'rightAlt': substitute(&commentstring, '.*%s\s*\(.*\)', '\1', 'g') }
+    endif
 endfunction
 
 " Function: s:SwitchToAlternativeDelimiters(printMsgs) function {{{2


### PR DESCRIPTION
If NERD Commenter does not have a delim map for a filetype, it parses
the &commentstring variable. This is fine when Vim knows the filetype
and has a suitable comment string for it, but for unknown filetypes Vim
defaults to '/_%s_/', and that is far less common than files with '# %s'
comments.

Solution: if &filetype is empty, parse &commentstring is into
the alt delims, and set '#' as the main left delim.
